### PR TITLE
pyo3 doesn't require nightly since v0.11.1

### DIFF
--- a/content/libraries/pyo3-python-rust.md
+++ b/content/libraries/pyo3-python-rust.md
@@ -6,5 +6,4 @@ url: "https://github.com/PyO3/pyo3/blob/master/README.md#using-rust-from-python"
 host_lang: Python
 guest_lang: Rust
 description: "Rust bindings for Python. This includes running and interacting with Python code from a Rust binary, as well as writing native Python modules."
-requires_nightly: true
 ---

--- a/content/libraries/pyo3-rust-python.md
+++ b/content/libraries/pyo3-rust-python.md
@@ -6,5 +6,4 @@ url: "https://github.com/PyO3/pyo3/blob/master/README.md#using-python-from-rust"
 host_lang: Rust
 guest_lang: Python
 description: "Rust bindings for Python. This includes running and interacting with Python code from a Rust binary, as well as writing native Python modules."
-requires_nightly: true
 ---


### PR DESCRIPTION
pyo3 doesn't require nightly since v0.11.1 as explained [here](https://pyo3.rs/v0.11.1/migration.html#from-010-to-011)